### PR TITLE
Remove Ground and Satellite Tags once the packet has been transmitted.

### DIFF
--- a/model/ground-sta-net-device.cc
+++ b/model/ground-sta-net-device.cc
@@ -387,6 +387,9 @@ GroundStaNetDevice::TransmitComplete (const Ptr<Packet> &packet)
   m_phyTxEndTrace (packet);
   m_txMachineState = IDLE;
 
+  GroundSatTag tag;
+  packet->RemovePacketTag (tag);
+
   if (GetQueue ()->IsEmpty () == false)
     {
       auto next_packet = GetQueue ()->Dequeue ();

--- a/model/sat2ground-net-device.cc
+++ b/model/sat2ground-net-device.cc
@@ -324,6 +324,9 @@ Sat2GroundNetDevice::TransmitComplete (const Ptr<Packet> &packet)
   m_phyTxEndTrace (packet);
   m_txMachineState = IDLE;
 
+  SatGroundTag tag;
+  packet->RemovePacketTag (tag);
+
   if (GetQueue ()->IsEmpty () == false)
     {
       auto next_packet = GetQueue ()->Dequeue ();


### PR DESCRIPTION
This is a fix for issue #30.

