### PR TITLE
Run actions on our self-hosted server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,15 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   build:
+    strategy:
+      matrix:
+        build: [debug, optimized]
+        compiler: [g++-10, clang++-12]
+
     # The type of runner that the job will run on
     runs-on: self-hosted
 
+    name: Build ${{ matrix.build }} with ${{ matrix.compiler }}
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout pybindgen
@@ -49,7 +55,7 @@ jobs:
       - name: Configure
         run: |
           cd ns-3
-          ./waf configure --enable-tests -o build/ --enable-modules=icarus,point-to-point-layout
+          CXX=${{ matrix.compiler }} ./waf configure -d ${{ matrix.build }} --enable-tests -o build/${{ matrix.build }}/${{ matrix.compiler }} --enable-modules=icarus,point-to-point-layout
       - name: Build
         run: |
           cd ns-3


### PR DESCRIPTION
This will speed up the compilation process and avoid consuming the limit of 60 minutes per month in Github instances.