### PR TITLE
Simplify PoissonHelper

### DIFF
--- a/helper/poisson-helper.cc
+++ b/helper/poisson-helper.cc
@@ -35,8 +35,8 @@ namespace icarus {
 const DataRate PoissonHelper::POISSON_MAX_DATA_RATE{"1Gbps"};
 
 PoissonHelper::PoissonHelper (const std::string &protocol, const Address &address,
-                              DataRate poissonRate, uint32_t packetSize,
-                              uint32_t headerSize) noexcept
+                              DataRate poissonRate, uint32_t headerSize,
+                              uint32_t packetSize) noexcept
 
     : m_impl (std::make_unique<OnOffHelper> (protocol, address))
 {

--- a/helper/poisson-helper.h
+++ b/helper/poisson-helper.h
@@ -55,7 +55,7 @@ public:
    * \param packetSize Size in bytes of the packet payloads generated
    */
   PoissonHelper (const std::string &protocol, const Address &address, DataRate poissonRate,
-                 uint32_t packetSize = 512u, uint32_t headerSize = 0u) noexcept;
+                 uint32_t headerSize, uint32_t packetSize = 512u) noexcept;
 
   /**
    * Helper function used to set the underlying application attributes.


### PR DESCRIPTION
This new version avoids copying code from OnOffHelper and, instead,
it delegates its implementation on it.