### PR TITLE
Use boost::optional to store m_busyPeriodPacketUid

### DIFF
--- a/model/mac/aloha-mac-model.cc
+++ b/model/mac/aloha-mac-model.cc
@@ -44,7 +44,7 @@ AlohaMacModel::GetTypeId (void)
   return tid;
 }
 
-AlohaMacModel::AlohaMacModel () : m_busyPeriodPacketUid (0), m_busyPeriodCollision (false)
+AlohaMacModel::AlohaMacModel () : m_busyPeriodPacketUid (boost::none), m_busyPeriodCollision (false)
 {
   NS_LOG_FUNCTION (this);
 }
@@ -75,18 +75,18 @@ AlohaMacModel::NewPacketRx (const Ptr<Packet> &packet, Time packet_tx_time)
   NS_LOG_FUNCTION (this << packet << packet_tx_time);
 
   Time now = Simulator::Now ();
-  if (m_busyPeriodPacketUid > 0 && now < m_busyPeriodFinishTime)
+  if (m_busyPeriodPacketUid && now < m_busyPeriodFinishTime)
     {
       m_busyPeriodCollision = true;
       NS_LOG_LOGIC ("Packet " << packet->GetUid () << " causes collision");
     }
 
   Time finish_tx_time = now + packet_tx_time;
-  if (m_busyPeriodPacketUid == 0 || finish_tx_time >= m_busyPeriodFinishTime)
+  if (!m_busyPeriodPacketUid || finish_tx_time >= m_busyPeriodFinishTime)
     {
       m_busyPeriodPacketUid = packet->GetUid ();
       m_busyPeriodFinishTime = finish_tx_time;
-      NS_LOG_LOGIC ("Updating busy period info: " << m_busyPeriodPacketUid << " "
+      NS_LOG_LOGIC ("Updating busy period info: " << m_busyPeriodPacketUid.value () << " "
                                                   << m_busyPeriodFinishTime);
     }
 }
@@ -110,7 +110,7 @@ AlohaMacModel::HasCollided (const Ptr<Packet> &packet)
 
   if (m_busyPeriodPacketUid == packet_uid)
     {
-      m_busyPeriodPacketUid = 0;
+      m_busyPeriodPacketUid = boost::none;
       m_busyPeriodFinishTime = Simulator::Now ();
       m_busyPeriodCollision = false;
       NS_LOG_LOGIC ("Cleaning busy period info");

--- a/model/mac/aloha-mac-model.h
+++ b/model/mac/aloha-mac-model.h
@@ -26,6 +26,8 @@
 #include "mac-model.h"
 #include "ns3/nstime.h"
 
+#include <boost/optional.hpp>
+
 namespace ns3 {
 namespace icarus {
 
@@ -41,7 +43,7 @@ public:
 
 private:
   Time m_slotDuration;
-  uint64_t m_busyPeriodPacketUid;
+  boost::optional<uint64_t> m_busyPeriodPacketUid;
   Time m_busyPeriodFinishTime;
   bool m_busyPeriodCollision;
 };


### PR DESCRIPTION
This is a minor nitpick. PacketGUID can be 0 (in fact, it is
usually 0 for the first simulated packet), so it is not correct
to use 0 to signal "no packet".
Instead, we hold the value in a boost::optional, so we have two
clear states: no packet (boost::none) or a packet with any
uint64_t guid value.