### PR TITLE
Fix a thinko in Constellation::GetClosest

### DIFF
--- a/model/constellation.cc
+++ b/model/constellation.cc
@@ -1,6 +1,6 @@
 /* -*- Mode:C++; c-file-style:"gnu"; indent-tabs-mode:nil; -*- */
 /*
- * Copyright (c) 2021 Universidade de Vigo
+ * Copyright (c) 2021–2022 Universidade de Vigo
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -104,8 +104,9 @@ Constellation::GetClosest (Vector3D cartesianCoordinates) const
               continue;
             }
 
-          const auto sq_distance = getSqDistance (
-              sat_device->GetNode ()->GetObject<MobilityModel> ()->GetPosition (), bestPos);
+          const auto sq_distance =
+              getSqDistance (sat_device->GetNode ()->GetObject<MobilityModel> ()->GetPosition (),
+                             cartesianCoordinates);
           if (sq_distance <= sq_closest_distance)
             {
               sq_closest_distance = sq_distance;


### PR DESCRIPTION
The previous implementation found the closest location to the center
of the simulation (the center of the planet) instead of the intented
coordinates. Moreover, as all the simulated satellites orbit at the
same altitude, the result was essentially random.
This should fix the tracking behavior of ground stations.